### PR TITLE
Sets defaults the same as simplestyle-spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ function _makeLayer(feature) {
             type: 'line',
             id: feature.properties._id,
             paint: {
-                'line-color': feature.properties.stroke || '#ddd',
-                'line-width': feature.properties['stroke-width'] || '#ddd',
-                'line-opacity': feature.properties['stroke-opacity'] || 1
+                'line-color': 'stroke' in feature.properties ? feature.properties.stroke : '#555555',
+                'line-opacity': 'stroke-opacity' in feature.properties ? feature.properties['stroke-opacity'] : 1.0,
+                'line-width': 'stroke-width' in feature.properties ? feature.properties['stroke-width'] : 2
             },
             filter: [
                 '==',
@@ -49,11 +49,11 @@ function _makeLayer(feature) {
             type: 'fill',
             id: feature.properties._id,
             paint: {
-                'fill-color': feature.properties.fill  || '#ddd',
-                'fill-opacity': feature.properties['fill-opacity'] || 1,
-                'line-color': feature.properties.stroke || 1,
-                'line-width': feature.properties['stroke-width'] || 1,
-                'line-opacity': feature.properties['stroke-opacity'] || 1
+                'line-color': 'stroke' in feature.properties ? feature.properties.stroke : '#555555',
+                'line-opacity': 'stroke-opacity' in feature.properties ? feature.properties['stroke-opacity'] : 1.0,
+                'line-width': 'stroke-width' in feature.properties ? feature.properties['stroke-width'] : 2.0,
+                'fill-color': 'fill' in feature.properties ? feature.properties.fill : '#555555',
+                'fill-opacity': 'fill-opacity' in feature.properties ? feature.properties['fill-opacity'] : 0.5
             },
             filter: [
                 '==',

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ var test = require('tape');
 simpleToGL = require('./index.js');
 
 var validFeatureCollection = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"stroke":"#3eb367","stroke-width":2,"stroke-opacity":1},"geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","properties":{"stroke":"#5bfa35","stroke-width":2,"stroke-opacity":1,"fill":"#b87acb","fill-opacity":0.5},"geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
+var validFeatureCollectionWithNoProperties = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
 var invalidFeatureCollection = {"type":"FeatureCollection","foobar":[{"type":"Feature","properties":{"stroke":"#3eb367","stroke-width":2,"stroke-opacity":1},"geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","properties":{"stroke":"#5bfa35","stroke-width":2,"stroke-opacity":1,"fill":"#b87acb","fill-opacity":0.5},"geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
 var point = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[15.8203125,28.613459424004414]}}]};
 
@@ -22,6 +23,27 @@ test('valid', function(t) {
     t.deepEqual(style.layers[1].paint['line-opacity'], validFeatureCollection.features[1].properties['stroke-opacity'], 'Polyong line-opacity the same');
     t.deepEqual(style.layers[1].paint['fill-color'], validFeatureCollection.features[1].properties['fill'], 'Polyong fill-color the same');
     t.deepEqual(style.layers[1].paint['fill-opacity'], validFeatureCollection.features[1].properties['fill-opacity'], 'Polyong fill-opacity the same');
+
+    t.end();
+});
+
+test('valid with no properties', function(t) {
+    var style = simpleToGL(validFeatureCollectionWithNoProperties);
+    t.deepEqual(style.version, 8, 'Version should be 8');
+
+    for (var i = 0; i < style.sources.geojson.data.features.length; i++) {
+        t.deepEqual(style.layers[i].filter[2], style.sources.geojson.data.features[i].properties._id, 'ids match between geojson source and layer')
+    }
+
+    t.deepEqual(style.layers[0].paint['line-color'], '#555555', 'LineString line-color is default value');
+    t.deepEqual(style.layers[0].paint['line-opacity'], 1.0, 'LineString line-opacity is default value');
+    t.deepEqual(style.layers[0].paint['line-width'], 2.0, 'LineString line-width is default value');
+
+    t.deepEqual(style.layers[1].paint['line-color'], '#555555', 'Polyong line-color is default value');
+    t.deepEqual(style.layers[1].paint['line-opacity'], 1.0, 'Polyong line-opacity is default value');
+    t.deepEqual(style.layers[1].paint['line-width'], 2.0, 'Polyong line-width is default value');
+    t.deepEqual(style.layers[1].paint['fill-color'], '#555555', 'Polyong fill-color is default value');
+    t.deepEqual(style.layers[1].paint['fill-opacity'], 0.5, 'Polyong fill-opacity is default value');
 
     t.end();
 });


### PR DESCRIPTION
Close: https://github.com/mapbox/simplespec-to-gl-style/issues/2 and https://github.com/mapbox/simplespec-to-gl-style/issues/7

This sets the defaults to the same values found on simplestyle-spec and checks for no values better than with `||`.
