### PR TITLE
`type: fill` does not have stroke properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,23 +7,21 @@ function convert(geojson) {
         if (!geojson.features[i].properties) geojson.features[i].properties = {};
         geojson.features[i].properties._id = hat();
 
-
         var feature = geojson.features[i];
-        if (feature.geometry.type === 'Polygon') {
-            var inside = _makeLayer(feature, sourceId);
-            if (layer instanceof Error) return layer;
+        if (feature.geometry.type === 'LineString') {
+            var layer = _makeLayer(feature, sourceId, 'LineString');
+            layers.push(layer);
+
+        } else if (feature.geometry.type === 'Polygon') {
+            var inside = _makeLayer(feature, sourceId, 'Polygon');
             layers.push(inside);
 
             // Background: https://github.com/mapbox/simplespec-to-gl-style/issues/2
             // `type: fill` does not support stroke properties
-            feature.geometry.type = 'LineString';
-            var outside = _makeLayer(feature);
-            if (layer instanceof Error) return layer;
+            var outside = _makeLayer(feature, sourceId, 'LineString');
             layers.push(outside);
         } else {
-            var layer = _makeLayer(feature, sourceId);
-            if (layer instanceof Error) return layer;
-            layers.push(layer);
+            return new Error('Unsupported geometry type');
         }
     }
 
@@ -39,11 +37,9 @@ function convert(geojson) {
     return style;
 }
 
-function _makeLayer(feature, sourceId) {
-    if (feature.geometry.type !== 'LineString' && feature.geometry.type !== 'Polygon') return new Error('Unsupported geometry type');
-
+function _makeLayer(feature, sourceId, geometry) {
     var layer;
-    if (feature.geometry.type === 'LineString') {
+    if (geometry === 'LineString') {
         layer = {
             type: 'line',
             source: sourceId,
@@ -59,7 +55,7 @@ function _makeLayer(feature, sourceId) {
                 feature.properties._id
             ]
         };
-    } else if (feature.geometry.type === 'Polygon') {
+    } else if (geometry === 'Polygon') {
         layer = {
             type: 'fill',
             source: sourceId,

--- a/test.js
+++ b/test.js
@@ -14,15 +14,18 @@ test('valid', function(t) {
         t.deepEqual(style.layers[i].filter[2], style.sources.geojson.data.features[i].properties._id, 'ids match between geojson source and layer')
     }
 
+    t.deepEqual(style.layers.length, 3, 'Should create 3 layers: 1 for LineString, and 2 for polygon');
+
     t.deepEqual(style.layers[0].paint['line-color'], validFeatureCollection.features[0].properties['stroke'], 'LineString line-color the same');
     t.deepEqual(style.layers[0].paint['line-width'], validFeatureCollection.features[0].properties['stroke-width'], 'LineString line-width the same');
     t.deepEqual(style.layers[0].paint['line-opacity'], validFeatureCollection.features[0].properties['stroke-opacity'], 'LineString line-opacity the same');
 
-    t.deepEqual(style.layers[1].paint['line-color'], validFeatureCollection.features[1].properties['stroke'], 'Polyong line-color the same');
-    t.deepEqual(style.layers[1].paint['line-width'], validFeatureCollection.features[1].properties['stroke-width'], 'Polyong line-width the same');
-    t.deepEqual(style.layers[1].paint['line-opacity'], validFeatureCollection.features[1].properties['stroke-opacity'], 'Polyong line-opacity the same');
     t.deepEqual(style.layers[1].paint['fill-color'], validFeatureCollection.features[1].properties['fill'], 'Polyong fill-color the same');
     t.deepEqual(style.layers[1].paint['fill-opacity'], validFeatureCollection.features[1].properties['fill-opacity'], 'Polyong fill-opacity the same');
+
+    t.deepEqual(style.layers[2].paint['line-color'], validFeatureCollection.features[1].properties['stroke'], 'LineString line-color the same');
+    t.deepEqual(style.layers[2].paint['line-width'], validFeatureCollection.features[1].properties['stroke-width'], 'LineString line-width the same');
+    t.deepEqual(style.layers[2].paint['line-opacity'], validFeatureCollection.features[1].properties['stroke-opacity'], 'LineString line-opacity the same');
 
     t.end();
 });
@@ -39,11 +42,12 @@ test('valid with no properties', function(t) {
     t.deepEqual(style.layers[0].paint['line-opacity'], 1.0, 'LineString line-opacity is default value');
     t.deepEqual(style.layers[0].paint['line-width'], 2.0, 'LineString line-width is default value');
 
-    t.deepEqual(style.layers[1].paint['line-color'], '#555555', 'Polyong line-color is default value');
-    t.deepEqual(style.layers[1].paint['line-opacity'], 1.0, 'Polyong line-opacity is default value');
-    t.deepEqual(style.layers[1].paint['line-width'], 2.0, 'Polyong line-width is default value');
     t.deepEqual(style.layers[1].paint['fill-color'], '#555555', 'Polyong fill-color is default value');
     t.deepEqual(style.layers[1].paint['fill-opacity'], 0.5, 'Polyong fill-opacity is default value');
+
+    t.deepEqual(style.layers[2].paint['line-color'], '#555555', 'LineString line-color is default value');
+    t.deepEqual(style.layers[2].paint['line-opacity'], 1.0, 'LineString line-opacity is default value');
+    t.deepEqual(style.layers[2].paint['line-width'], 2.0, 'LineString line-width is default value');
 
     t.end();
 });


### PR DESCRIPTION
closes https://github.com/mapbox/simplespec-to-gl-style/issues/2

Because of this, we need to mutate type polygon and force it to be a linestring.

/cc @jfirebaugh for review
