### PR TITLE
Add background circle to symbols

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var test = require('tape');
-simpleToGL = require('./index.js');
+var simpleToGL = require('./index.js');
 
+/* eslint-disable */
 var validFeatureCollection = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"stroke":"#3eb367","stroke-width":2,"stroke-opacity":1},"geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","properties":{"stroke":"#5bfa35","stroke-width":2,"stroke-opacity":1,"fill":"#b87acb","fill-opacity":0.5},"geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
 var validFeatureCollectionWithNoProperties = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
 var invalidFeatureCollection = {"type":"FeatureCollection","foobar":[{"type":"Feature","properties":{"stroke":"#3eb367","stroke-width":2,"stroke-opacity":1},"geometry":{"type":"LineString","coordinates":[[40.78125,57.32652122521709],[10.546875,41.244772343082076],[57.65624999999999,18.312810846425442]]}},{"type":"Feature","properties":{"stroke":"#5bfa35","stroke-width":2,"stroke-opacity":1,"fill":"#b87acb","fill-opacity":0.5},"geometry":{"type":"Polygon","coordinates":[[[-23.5546875,23.88583769986199],[-31.640625,-8.05922962720018],[8.7890625,-8.05922962720018],[-23.5546875,23.88583769986199]]]}}]};
@@ -8,6 +9,7 @@ var invalidFeatureCollectionType = {"type":"foobar","features":[{"type":"Feature
 var point = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[15.8203125,28.613459424004414]}}]};
 var pointWithImageAndSize = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#7e7e7e","marker-symbol":"airport-11","marker-size":"large"},"geometry":{"type":"Point","coordinates":[28.4765625,16.63619187839765]}}]};
 var singleGeoJSONFeature = {"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[36.2109375,60.06484046010452],[-4.921875,47.98992166741417],[14.0625,3.8642546157214213],[61.52343749999999,16.63619187839765],[36.2109375,60.06484046010452]]]}};
+/* eslint-enable */
 
 test('valid', function(t) {
     var style = simpleToGL(validFeatureCollection);
@@ -16,7 +18,7 @@ test('valid', function(t) {
     for (var key in style.sources) {
        var source = style.sources[key];
        for (var i = 0; i < source.data.features.length; i++) {
-           t.deepEqual(style.layers[i].filter[2], source.data.features[i].properties._id, 'ids match between geojson source and layer')
+           t.deepEqual(style.layers[i].filter[2], source.data.features[i].properties._id, 'ids match between geojson source and layer');
        }
     }
 
@@ -44,7 +46,7 @@ test('valid with no properties', function(t) {
     for (var key in style.sources) {
        var source = style.sources[key];
        for (var i = 0; i < source.data.features.length; i++) {
-           t.deepEqual(style.layers[i].filter[2], source.data.features[i].properties._id, 'ids match between geojson source and layer')
+           t.deepEqual(style.layers[i].filter[2], source.data.features[i].properties._id, 'ids match between geojson source and layer');
        }
     }
 
@@ -86,6 +88,7 @@ test('valid single feature', function(t) {
 test('valid single point defaults to circle', function(t) {
     var style = simpleToGL(point);
     t.deepEqual(style.version, 8, 'Version should be 8');
+    t.deepEqual(style.layers[0].type, 'circle', 'Default circle');
     t.deepEqual(style.layers[0].paint['circle-color'], '#555555', 'Default marker');
     t.deepEqual(style.layers[0].paint['circle-radius'], 5, 'Default size');
     t.end();
@@ -94,22 +97,29 @@ test('valid single point defaults to circle', function(t) {
 test('valid single point with image', function(t) {
     var style = simpleToGL(pointWithImageAndSize);
     t.deepEqual(style.version, 8, 'Version should be 8');
-    t.deepEqual(style.layers[0].layout['icon-image'], 'airport-11', 'Custom marker');
-    t.deepEqual(style.layers[0].layout['icon-size'], 1.5, 'Custom size');
+
+    t.deepEqual(style.layers[0].type, 'circle', 'Default circle');
+    t.deepEqual(style.layers[0].paint['circle-color'], '#7e7e7e', 'Default marker');
+    t.deepEqual(style.layers[0].paint['circle-radius'], 10, 'Default size');
+
+    t.deepEqual(style.layers[1].type, 'symbol');
+    t.deepEqual(style.layers[1].layout['icon-image'], 'airport-11', 'Custom marker');
+    t.deepEqual(style.layers[1].layout['icon-size'], 1, 'Custom size');
+
     t.end();
 });
 
 test('invalid image size defaults to 1', function(t) {
-    var invalid = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#7e7e7e","marker-symbol":"airport-11","marker-size":"super-large"},"geometry":{"type":"Point","coordinates":[28.4765625,16.63619187839765]}}]};
+    var invalid = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#7e7e7e","marker-symbol":"airport-11","marker-size":"super-large"},"geometry":{"type":"Point","coordinates":[28.4765625,16.63619187839765]}}]}; // eslint-disable-line
     var style = simpleToGL(invalid);
     t.deepEqual(style.version, 8, 'Version should be 8');
-    t.deepEqual(style.layers[0].layout['icon-size'], 1, 'Default size');
+    t.deepEqual(style.layers[1].layout['icon-size'], 1, 'Default size');
     t.end();
 });
 
 test('invalid FeatureCollection', function(t) {
     t.throws(function() {
-        var style = simpleToGL(invalidFeatureCollectionType);
+        simpleToGL(invalidFeatureCollectionType);
     }, {
       message: 'unknown or unsupported GeoJSON type'
     }, 'Invalid GeoJSON type');


### PR DESCRIPTION
Closes https://github.com/mapbox/simplespec-to-gl-style/issues/18

When a symbol is rendered, a circle will also be rendered behind. The idea here is that the symbol color remains constant while the circle layer is used for customizing the color.

/cc @samanpwbb 
