### PR TITLE
handle points the same way

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,4 @@
 var hat = require('hat');
-var markerSize = {
-    small: 0.5,
-    medium: 0.75,
-    large: 1
-};
 
 function convert(geojson) {
     var sourceId = hat();
@@ -29,7 +24,6 @@ function addLayers(geojson, sourceId, layers) {
                 case 'Point':
                     if (!geojson.properties) geojson.properties = {};
                     geojson.properties._id = hat();
-                    if ('marker-symbol' in geojson.properties) layers.push(makeLayer(geojson, sourceId, 'symbol-background'));
                     layers.push(makeLayer(geojson, sourceId, 'Point'));
                     break;
                 case 'LineString':
@@ -51,14 +45,14 @@ function addLayers(geojson, sourceId, layers) {
 
 function makeLayer(feature, sourceId, geometry) {
     var layer;
-    if (geometry === 'symbol-background') { // Used for styling point background circle
+    if (geometry === 'Point') {
         layer = {
             source: sourceId,
             id: hat(),
-            type: 'circle',
-            paint: {
-                'circle-color': 'marker-color' in feature.properties ? feature.properties['marker-color'] : '#ddd',
-                'circle-radius': 'marker-size' in feature.properties && markerSize[feature.properties['marker-size']] ? markerSize[feature.properties['marker-size']] * 12 : 12
+            type: 'symbol',
+            layout: {
+                'icon-image': feature.properties._id,
+                'icon-size': 1
             },
             filter: [
                 '==',
@@ -66,33 +60,6 @@ function makeLayer(feature, sourceId, geometry) {
                 feature.properties._id
             ]
         };
-    } else if (geometry === 'Point') {
-        layer = {
-            source: sourceId,
-            id: hat(),
-            filter: [
-                '==',
-                '_id',
-                feature.properties._id
-            ]
-        };
-
-        if ('marker-symbol' in feature.properties) {
-            layer.type = 'symbol';
-            layer.layout = {};
-            layer.layout = {
-                'icon-image': feature.properties['marker-symbol'] + '-15',
-                'icon-size': 'marker-size' in feature.properties && markerSize[feature.properties['marker-size']] ? markerSize[feature.properties['marker-size']] : 1
-            };
-        } else {
-            layer.paint = {};
-            layer.type = 'circle';
-            layer.paint = {
-                'circle-color': 'marker-color' in feature.properties ? feature.properties['marker-color'] : '#555555',
-                'circle-radius': 'marker-size' in feature.properties && markerSize[feature.properties['marker-size']] ? feature.properties['marker-size'] * 5 : 5
-            };
-        }
-
     } else if (geometry === 'LineString') {
         layer = {
             type: 'line',
@@ -100,8 +67,8 @@ function makeLayer(feature, sourceId, geometry) {
             id: hat(),
             paint: {
                 'line-color': 'stroke' in feature.properties ? feature.properties.stroke : '#555555',
-                'line-opacity': 'stroke-opacity' in feature.properties ? feature.properties['stroke-opacity'] : 1.0,
-                'line-width': 'stroke-width' in feature.properties ? feature.properties['stroke-width'] : 2
+                'line-opacity': 'stroke-opacity' in feature.properties ? ++feature.properties['stroke-opacity'] : 1.0,
+                'line-width': 'stroke-width' in feature.properties ? ++feature.properties['stroke-width'] : 2
             },
             filter: [
                 '==',
@@ -116,7 +83,7 @@ function makeLayer(feature, sourceId, geometry) {
             id: hat(),
             paint: {
                 'fill-color': 'fill' in feature.properties ? feature.properties.fill : '#555555',
-                'fill-opacity': 'fill-opacity' in feature.properties ? feature.properties['fill-opacity'] : 0.5
+                'fill-opacity': 'fill-opacity' in feature.properties ? ++feature.properties['fill-opacity'] : 0.5
             },
             filter: [
                 '==',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "simplespec-to-gl-style",
+  "name": "@mapbox/simplespec-to-gl-style",
   "version": "0.1.0",
   "description": "Converts GeoJSON styled with simplestyle-spec to a GL Style",
   "main": "index.js",

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,16 @@
 
 Converts GeoJSON styled with [simplestyle-spec](https://github.com/mapbox/simplestyle-spec/) to a GL Style
 
+## Install
+
+```
+npm install @mapbox/simplespec-to-gl-style --save
+```
 
 #### Usage:
 
 ```js
-var convert = require('simplespec-to-gl-style');
+var convert = require('@mapbox/simplespec-to-gl-style');
 
 var style = convert(myGeoJSON);
 

--- a/test.js
+++ b/test.js
@@ -85,26 +85,20 @@ test('valid single feature', function(t) {
     t.end();
 });
 
-test('valid single point defaults to circle', function(t) {
+test('valid single point defaults to point', function(t) {
     var style = simpleToGL(point);
     t.deepEqual(style.version, 8, 'Version should be 8');
-    t.deepEqual(style.layers[0].type, 'circle', 'Default circle');
-    t.deepEqual(style.layers[0].paint['circle-color'], '#555555', 'Default marker');
-    t.deepEqual(style.layers[0].paint['circle-radius'], 5, 'Default size');
+    t.deepEqual(style.layers[0].type, 'symbol', 'Default symbol');
+    t.deepEqual(style.layers[0].layout['icon-size'], 1);
     t.end();
 });
 
 test('valid single point with image', function(t) {
     var style = simpleToGL(pointWithImageAndSize);
     t.deepEqual(style.version, 8, 'Version should be 8');
-
-    t.deepEqual(style.layers[0].type, 'circle', 'Default circle');
-    t.deepEqual(style.layers[0].paint['circle-color'], '#7e7e7e', 'Default marker');
-    t.deepEqual(style.layers[0].paint['circle-radius'], 12, 'Default size');
-
-    t.deepEqual(style.layers[1].type, 'symbol');
-    t.deepEqual(style.layers[1].layout['icon-image'], 'airport-15', 'Custom marker');
-    t.deepEqual(style.layers[1].layout['icon-size'], 1, 'Custom size');
+    t.deepEqual(style.layers[0].type, 'symbol');
+    t.ok(style.layers[0].layout['icon-image'], 'Custom marker');
+    t.deepEqual(style.layers[0].layout['icon-size'], 1, 'Custom size');
 
     t.end();
 });
@@ -113,7 +107,7 @@ test('invalid image size defaults to 1', function(t) {
     var invalid = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#7e7e7e","marker-symbol":"airport","marker-size":"super-large"},"geometry":{"type":"Point","coordinates":[28.4765625,16.63619187839765]}}]}; // eslint-disable-line
     var style = simpleToGL(invalid);
     t.deepEqual(style.version, 8, 'Version should be 8');
-    t.deepEqual(style.layers[1].layout['icon-size'], 1, 'Default size');
+    t.deepEqual(style.layers[0].layout['icon-size'], 1, 'Default size');
     t.end();
 });
 


### PR DESCRIPTION
This:

* Properly parses numbers as numbers and not as strings
* Removes the background circle from points
* moves to the `@mapbox` npm org