### PR TITLE
Account for lines with fill properties. Also move to cuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var hat = require('hat');
+var cuid = require('cuid');
 
 function convert(geojson) {
-    var sourceId = hat();
+    var sourceId = cuid();
 
     var style = {
         version: 8,
@@ -23,17 +23,22 @@ function addLayers(geojson, sourceId, layers) {
             switch (geojson.geometry.type) {
                 case 'Point':
                     if (!geojson.properties) geojson.properties = {};
-                    geojson.properties._id = hat();
+                    geojson.properties._id = cuid();
                     layers.push(makeLayer(geojson, sourceId, 'Point'));
                     break;
                 case 'LineString':
                     if (!geojson.properties) geojson.properties = {};
-                    geojson.properties._id = hat();
+                    geojson.properties._id = cuid();
                     layers.push(makeLayer(geojson, sourceId, 'LineString'));
+
+                    // Encoded polylines can be rendered as polgons. If a LineString has fill properties, add them.
+                    if ('fill' in geojson.properties || 'fill-opacity' in geojson.properties) {
+                        layers.push(makeLayer(geojson, sourceId, 'Polygon'));
+                    }
                     break;
                 case 'Polygon':
                     if (!geojson.properties) geojson.properties = {};
-                    geojson.properties._id = hat();
+                    geojson.properties._id = cuid();
                     layers.push(makeLayer(geojson, sourceId, 'LineString'));
                     layers.push(makeLayer(geojson, sourceId, 'Polygon'));
                     break;
@@ -48,7 +53,7 @@ function makeLayer(feature, sourceId, geometry) {
     if (geometry === 'Point') {
         layer = {
             source: sourceId,
-            id: hat(),
+            id: cuid(),
             type: 'symbol',
             layout: {
                 'icon-image': feature.properties._id,
@@ -64,7 +69,7 @@ function makeLayer(feature, sourceId, geometry) {
         layer = {
             type: 'line',
             source: sourceId,
-            id: hat(),
+            id: cuid(),
             paint: {
                 'line-color': 'stroke' in feature.properties ? feature.properties.stroke : '#555555',
                 'line-opacity': 'stroke-opacity' in feature.properties ? +feature.properties['stroke-opacity'] : 1.0,
@@ -84,7 +89,7 @@ function makeLayer(feature, sourceId, geometry) {
         layer = {
             type: 'fill',
             source: sourceId,
-            id: hat(),
+            id: cuid(),
             paint: {
                 'fill-color': 'fill' in feature.properties ? feature.properties.fill : '#555555',
                 'fill-opacity': 'fill-opacity' in feature.properties ? +feature.properties['fill-opacity'] : 0.5

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Bobby Sudekum",
   "license": "ISC",
   "dependencies": {
-    "hat": "0.0.3"
+    "cuid": "^1.3.8"
   },
   "devDependencies": {
     "eslint": "^3.1.1",

--- a/test.js
+++ b/test.js
@@ -119,3 +119,15 @@ test('invalid FeatureCollection', function(t) {
     }, 'Invalid GeoJSON type');
     t.end();
 });
+
+
+test('LineString with fill properties', function(t) {
+    var geojson = {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"stroke-width":"2","stroke":"#000000","stroke-opacity":"1.0","fill":"#ff0000","fill-opacity":"0.25"},"geometry":{"type":"LineString","coordinates":[[-122.68209,45.52475],[-122.67488,45.52451],[-122.67608,45.51681],[-122.68998,45.51693],[-122.68964,45.5203],[-122.68209,45.52475]]}}]};  // eslint-disable-line
+    var style = simpleToGL(geojson);
+
+    t.equal(style.layers.length, 2, 'Has two layers');
+    t.equal(style.layers[1].type, 'fill');
+    t.equal(style.layers[1].paint['fill-color'], '#ff0000');
+    t.equal(style.layers[1].paint['fill-opacity'], 0.25);
+    t.end();
+});


### PR DESCRIPTION
This PR accounts for lines that have fill properties and also moves off of hat from cuid. 

/cc @1ec5 