### PR TITLE
Always allow markers to overlap

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ function makeLayer(feature, sourceId, geometry) {
             type: 'symbol',
             layout: {
                 'icon-image': feature.properties._id,
-                'icon-size': 1
+                'icon-size': 1,
+                'icon-allow-overlap': true
             },
             filter: [
                 '==',

--- a/test.js
+++ b/test.js
@@ -98,6 +98,7 @@ test('valid single point with image', function(t) {
     t.deepEqual(style.version, 8, 'Version should be 8');
     t.deepEqual(style.layers[0].type, 'symbol');
     t.ok(style.layers[0].layout['icon-image'], 'Custom marker');
+    t.ok(style.layers[0].layout['icon-allow-overlap'], 'Allow marker overlap');
     t.deepEqual(style.layers[0].layout['icon-size'], 1, 'Custom size');
 
     t.end();


### PR DESCRIPTION
Before if two markers were close together, only one would show up. This always renders all markers on the map.

/cc @colleenmcginnis 