### PR TITLE
Sets icon-ignore-placement to true for markers

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ function makeLayer(feature, sourceId, geometry) {
             layout: {
                 'icon-image': feature.properties._id,
                 'icon-size': 1,
-                'icon-allow-overlap': true
+                'icon-allow-overlap': true,
+                'icon-ignore-placement': true
             },
             filter: [
                 '==',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/simplespec-to-gl-style",
-  "version": "0.3.2",
+  "version": "0.4.0-dev",
   "description": "Converts GeoJSON styled with simplestyle-spec to a GL Style",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/simplespec-to-gl-style",
-  "version": "0.4.0-dev",
+  "version": "0.4.0",
   "description": "Converts GeoJSON styled with simplestyle-spec to a GL Style",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now [icon-ignore-placement](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-icon-ignore-placement) is set to `true` for all points, which allows more symbols to be visible:

![Screen Shot 2020-03-06 at 1 24 21 PM](https://user-images.githubusercontent.com/2426620/76227199-4e7e4000-61f5-11ea-969b-72ad965a6983.png)
